### PR TITLE
[infra] - Bump onnxruntime to 1.30.0 and the pydantic pair to 2.13.5/2.46.5

### DIFF
--- a/.claude/skills/dep-guard/check_deps.py
+++ b/.claude/skills/dep-guard/check_deps.py
@@ -47,11 +47,11 @@ import tomllib
 from pathlib import Path
 from typing import NamedTuple
 
-# The pydantic family bumps in lock-step: pydantic 2.13.4 hard-pins
-# pydantic-core==2.46.4 (exact ==). Bumping one alone makes
+# The pydantic family bumps in lock-step: pydantic 2.13.5 hard-pins
+# pydantic-core==2.46.5 (exact ==). Bumping one alone makes
 # `pip install -c constraints.txt` unresolvable (CLAUDE.md §4). Drift from this
 # documented pair is a conscious update, not a silent one -> WARN, not FAIL.
-_PYDANTIC_LOCKSTEP = {"pydantic": "2.13.4", "pydantic-core": "2.46.4"}
+_PYDANTIC_LOCKSTEP = {"pydantic": "2.13.5", "pydantic-core": "2.46.5"}
 
 _fails: list[dict[str, str]] = []
 _warns: list[dict[str, str]] = []

--- a/.claude/skills/dep-guard/verify.sh
+++ b/.claude/skills/dep-guard/verify.sh
@@ -58,8 +58,13 @@ fi
 echo "mutation B (D4 uvicorn extra): PASS (exit 2, D4 reported)"
 
 # 2c. D1 WARN: drift pydantic-core out of the documented lock-step.
+# Rewrites WHATEVER pydantic-core version is pinned, not a literal current one:
+# a hardcoded 's/pydantic-core==2.46.4/.../' matched nothing the moment the pair
+# moved (caught on the 2.46.4 -> 2.46.5 bump, 2026-09-11), so no drift was
+# introduced and the missing WARN read as a checker regression instead of a
+# stale fixture. The replacement just has to differ from the real pin.
 c="$(_mktree)"
-sed -i.bak 's/pydantic-core==2.46.4/pydantic-core==2.47.0/' "$c/constraints.txt"
+sed -i.bak -E 's/^pydantic-core==.*/pydantic-core==99.99.99/' "$c/constraints.txt"
 if ! python3 "$checker" --repo-root "$c" >/tmp/depguard_warn.txt 2>&1; then
   echo "mutation C (D1): FAIL — a WARN alone must not fail (expected exit 0)" >&2
   cat /tmp/depguard_warn.txt >&2; rm -rf "$c"; exit 1

--- a/.claude/skills/otel-hardening/check_otel.py
+++ b/.claude/skills/otel-hardening/check_otel.py
@@ -241,8 +241,8 @@ INVENTORY: tuple[dict[str, object], ...] = (
         "controls": {"ORT_DISABLE_TELEMETRY": "1"},
         "url": "https://github.com/microsoft/onnxruntime/blob/main/docs/Privacy.md",
         "versions": "transitive (chromadb, which asks only for >=1.14.1; fastembed under the "
-                    "guardrails extra) -- bounded at ==1.29.0 in constraints.txt so the env "
-                    "control cannot be resolved below the release that introduced it",
+                    "guardrails extra) -- bounded at ==1.30.0 in constraints.txt, at or above "
+                    "the v1.29.0 release that introduced the env control, so it cannot resolve below it",
         "enforcement": "env before import (process-lifetime control for the non-Windows 1DS path added in "
                        "v1.29.0, PRs #27379/#29872) + onnxruntime.disable_telemetry_events() at the load "
                        "seams (utils/onnx_telemetry.py) before session construction. Windows is "
@@ -250,8 +250,10 @@ INVENTORY: tuple[dict[str, object], ...] = (
                        "an init-time event, and absolute suppression needs a --no_telemetry private build. "
                        "ORT_TELEMETRY_OPT_OUT is an inert legacy marker, not protection.",
         "scope": "chromadb default-EF path (never invoked -- precomputed vectors) + fastembed under live NeMo",
-        "reviewed": "2026-08-27",
-        "evidence": "disable_telemetry_events present in installed 1.29.0; v1.29.0 release notes + Privacy.md",
+        "reviewed": "2026-09-11",
+        "evidence": "disable_telemetry_events verified callable in installed 1.30.0 (2026-09-11, on the pin bump "
+                    "from 1.29.0); v1.29.0 release notes + Privacy.md. Re-verify on every onnxruntime bump -- the "
+                    "API half of this control is only a getattr away from silently disappearing.",
     },
     {
         "name": "opentelemetry sdk", "category": 1,

--- a/.claude/skills/otel-hardening/verify.sh
+++ b/.claude/skills/otel-hardening/verify.sh
@@ -257,11 +257,20 @@ _expect "T14 dropped-seam mutation" 2 "FAIL  \[T14\]"
 # 22. T13: the ONNX floor pin is lowered below the release where
 #     ORT_DISABLE_TELEMETRY starts governing the non-Windows 1DS path. Both
 #     required surfaces must go red, not just report an info line.
+#     The mutation rewrites WHATEVER version is pinned rather than a literal
+#     current one: hardcoding "1.29.0" here made this scenario silently no-op
+#     the moment the pin moved off the floor (caught on the 1.29.0 -> 1.30.0
+#     bump, 2026-09-11 -- the sed matched nothing, so nothing was mutated and
+#     the clean tree's exit 0 read as a pass). The floor in the EXPECTED
+#     message stays literal: that number is the ORT release the control landed
+#     in, not a pin, and it does not move.
 a="$(_mktree)"
 _mutate "$a/constraints.txt" '
-text = text.replace("onnxruntime==1.29.0", "onnxruntime==1.28.0")'
+import re
+text = re.sub(r"(?m)^onnxruntime==[^\n]*$", "onnxruntime==1.28.0", text)'
 _mutate "$a/pyproject.toml" '
-text = text.replace("onnxruntime==1.29.0", "onnxruntime==1.28.0")'
+import re
+text = re.sub(r"\"onnxruntime==[^\"]*\"", "\"onnxruntime==1.28.0\"", text)'
 _expect "T13 ONNX floor lowered mutation" 2 "FAIL  \[T13\].*below the 1.29.0 floor"
 
 # 23. T13: the pins are deleted outright, as a future dependency edit might do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -515,7 +515,7 @@ mistake a capable-but-unfamiliar agent makes with the rule that prevents it.
 ### Dependencies
 - **Trap:** bumping `pydantic-core` alone, or adding `[standard]` to the uvicorn
   constraint. **Rule:** `pydantic` and `pydantic-core` are lock-step
-  (2.13.4 ↔ 2.46.4); the `uvicorn` constraint carries no extras (pip ≥26.1.2
+  (2.13.5 ↔ 2.46.5); the `uvicorn` constraint carries no extras (pip ≥26.1.2
   rejects extras in a constraints file).
 - **Trap:** letting numpy float to 2.x. **Rule:** numpy is pinned `<2`
   (dependabot ignores `numpy>=2.0.0`) — numpy 2 removes `np.float_` and breaks

--- a/constraints.txt
+++ b/constraints.txt
@@ -15,13 +15,16 @@
 # result. Current state: direct pins aligned with v1.9.0.
 
 # CRITICAL: pydantic family must stay synchronized or pip resolver explodes
-# pydantic 2.13.4 hard-pins pydantic-core==2.46.4 (exact ==, not a range), and
-# 2.13.4 is the latest pydantic on PyPI — no release pairs with pydantic-core
-# 2.47.0 yet. Bumping pydantic-core alone makes `pip install -c constraints.txt`
+# pydantic 2.13.5 hard-pins pydantic-core==2.46.5 (exact ==, not a range), and
+# 2.13.5 is the latest pydantic on PyPI. pydantic-core publishes AHEAD of its
+# parent -- 2.49.0 is its latest as of 2026-09-11 -- and no pydantic release
+# pairs with it yet, so PyPI's "newer pydantic-core" is never a bump candidate
+# on its own: bumping pydantic-core alone makes `pip install -c constraints.txt`
 # unresolvable. Keep these two in lock-step; only bump pydantic-core together
-# with a compatible pydantic bump.
-pydantic==2.13.4
-pydantic-core==2.46.4
+# with a compatible pydantic bump, and move dep-guard's _PYDANTIC_LOCKSTEP in
+# the same commit.
+pydantic==2.13.5
+pydantic-core==2.46.5
 # Not imported directly anywhere in CyClaw's own source and not in pyproject.toml's
 # [project.dependencies] -- but it IS a real, unconditional (non-extra) transitive
 # of chromadb==1.5.9 (`pydantic-settings>=2.0` in chromadb's own requires_dist), so
@@ -29,7 +32,7 @@ pydantic-core==2.46.4
 # removing it lets the resolver pick any pydantic-settings satisfying chromadb's
 # loose >=2.0 floor, which is exactly the reproducibility gap constraints.txt exists
 # to close. Kept lock-step-compatible with the pydantic pair above (requires
-# pydantic>=2.7.0; pinned pydantic==2.13.4 satisfies that).
+# pydantic>=2.7.0; pinned pydantic==2.13.5 satisfies that).
 pydantic-settings==2.14.2
 
 # Direct dependencies from pyproject.toml [project.dependencies] -- versions MUST match exactly
@@ -67,7 +70,12 @@ sentence-transformers==5.6.0
 # apply a constraints file; a constraints-only bound left those surfaces free
 # to resolve below the floor. Keep the two in step -- dep-guard D6 cross-checks
 # them, and otel-hardening T13 now validates each install surface separately.
-onnxruntime==1.29.0
+#
+# The pin sits ABOVE the floor, not on it: v1.29.0 is the release that
+# introduced the control, and the pin is free to move forward from there.
+# Do not "correct" it back down to 1.29.0 on the assumption that the pin and
+# the floor must be the same number -- only resolves BELOW 1.29.0 are unsafe.
+onnxruntime==1.30.0
 # Direct imports (retrieval/embeddings.py; gate.py), promoted
 # from implicit sentence-transformers/fastapi transitives to explicit pins --
 # see pyproject.toml [project.dependencies] for why.

--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   # 1.5.9 carries no such pin. Re-check this pin if chromadb is ever bumped here.
   - fastapi=0.115.9
   - uvicorn=0.51.0
-  - pydantic=2.13.4
+  - pydantic=2.13.5
   - pyyaml=6.0.3
   - httpx=0.28.1
   - langchain-core=1.5.0
@@ -127,7 +127,7 @@ dependencies:
       - websockets==15.0.1
       # Telemetry-control floor from the pip path (pyproject.toml/constraints.txt).
       # conda-forge chromadb=1.5.9 only declares onnxruntime>=1.14.1.
-      - onnxruntime==1.29.0
+      - onnxruntime==1.30.0
 
 # Optional: Create with mamba for speed
 # mamba env create -f environment.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ requires-python = ">=3.12,<3.13"
 dependencies = [
     "fastapi==0.139.2",
     "uvicorn[standard]==0.51.0",
-    "pydantic==2.13.4",
-    # pydantic-core is intentionally not pinned here: pydantic==2.13.4 hard-pins its
-    # exact pydantic-core (2.46.4), and constraints.txt locks that same version. The
+    "pydantic==2.13.5",
+    # pydantic-core is intentionally not pinned here: pydantic==2.13.5 hard-pins its
+    # exact pydantic-core (2.46.5), and constraints.txt locks that same version. The
     # dep-guard D1 lock-step check reads the pair from constraints.txt, not pyproject.
     "chromadb==1.5.9",  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md + pip-audit workflow.
     "sentence-transformers==5.6.0",
@@ -35,8 +35,10 @@ dependencies = [
     # below the floor. The floor is v1.29.0 because ORT_DISABLE_TELEMETRY
     # (utils/telemetry_kill.py) only governs the non-Windows 1DS telemetry
     # path from that release onward (PRs #27379/#29872); below it the env half
-    # of the ONNX control is inert on macOS and Linux.
-    "onnxruntime==1.29.0",
+    # of the ONNX control is inert on macOS and Linux. The pin may sit ABOVE
+    # that floor -- it does today -- only a resolve below 1.29.0 is unsafe, so
+    # do not "correct" it back down on the assumption pin and floor must match.
+    "onnxruntime==1.30.0",
     "starlette==1.3.1",
     "rank-bm25==0.2.2",
     "httpx==0.28.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ torch==2.13.0+cpu
 
 fastapi==0.139.2
 uvicorn[standard]==0.51.0
-pydantic==2.13.4
+pydantic==2.13.5
 pyyaml==6.0.3
 httpx==0.28.1
 websockets==15.0.1
@@ -42,7 +42,7 @@ starlette==1.3.1
 # Transitive of chromadb, pinned explicitly so this surface carries the same
 # onnxruntime floor pyproject.toml/constraints.txt do (ORT_DISABLE_TELEMETRY
 # governs the non-Windows 1DS path only from v1.29.0 -- see constraints.txt).
-onnxruntime==1.29.0
+onnxruntime==1.30.0
 rank-bm25==0.2.2
 numpy==1.26.4
 nltk==3.10.3


### PR DESCRIPTION
## Proposed changes

Two pin bumps surfaced by a `verify-deps` Step 5 currency sweep. **Neither closes a CVE** — OSV reports no advisory against the old or the new pin for either package. These were picked out of 27 currency gaps as the two that are both safe and verifiable today.

**`onnxruntime 1.29.0 → 1.30.0`.** The `1.29.0` in the surrounding comments is the *ORT release* that introduced `ORT_DISABLE_TELEMETRY`'s non-Windows 1DS coverage (PRs #27379/#29872) — a **floor, not the pin**. The pin now sits above it, and `constraints.txt` / `pyproject.toml` say so explicitly, because the failure mode here is a future reader "correcting" the pin back down to 1.29.0 on the assumption the two numbers must match. Only resolves *below* 1.29.0 are unsafe. Verified:

- `onnxruntime 1.30.0` requires only `numpy>=1.21.6` → the documented `numpy<2` ceiling is untouched.
- `onnxruntime.disable_telemetry_events` is still callable in 1.30.0. The API half of the ONNX control is one `getattr` away from silently disappearing on a bump, so `otel-hardening`'s `evidence` field now records the version actually checked and the date, instead of still claiming 1.29.0.
- `T13` passes on both required surfaces: `onnxruntime pinned 1.30.0 (>= 1.29.0)`.

**`pydantic 2.13.4 → 2.13.5` with `pydantic-core 2.46.4 → 2.46.5`.** The pair moves together or not at all — 2.13.5 hard-pins `pydantic-core==2.46.5` exactly. Worth recording because the sweep nearly produced a wrong answer here: **PyPI's newest `pydantic-core` is 2.49.0, which no `pydantic` release pairs with**, so "pydantic-core is three versions behind" is never a standalone bump candidate. The comments now state that rule rather than naming a version that dates, and `dep-guard`'s `_PYDANTIC_LOCKSTEP` moves in this same commit as `CLAUDE.md` requires.

**Invariant / Governance Impact:** none of the six invariants, and not I6. No change to `gate.py`, `gate_ops.py`, `gate_auth.py`, `gate_memory.py`, `graph.py`, `mcp_hybrid_server.py`, `config.yaml`, or any graph edge. `invariant-guard`: 46 passed, 0 failed. The one security-adjacent surface touched is the ONNX telemetry control, which is verified stronger-or-equal above, not weakened.

---

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Infrastructure / CI only — dependency pins across all four install surfaces, plus the two skill checkers that hardcode these numbers.

---

## Benefits / why

- **Every surface moves together.** `requirements.txt`, `constraints.txt`, `pyproject.toml`, `environment.yml` (conda-forge carries `pydantic 2.13.5`; `onnxruntime` rides its `pip:` tail), plus `CLAUDE.md`'s lock-step pair and the two checker constants. Bumping one pin file and leaving the others stale is the exact drift class `verify-deps` exists to catch, so leaving any behind would have been self-defeating.
- **Two mutation fixtures silently no-opped on this bump and are now version-agnostic.** This is the same rot class as the dead `E7` exemptions fixed in #1385, and both were caught by running the self-tests rather than by reasoning:
  - `otel-hardening/verify.sh` scenario 22 `sed`'d a literal `onnxruntime==1.29.0` to lower it below the floor. Once the pin moved off 1.29.0 the sed matched nothing, so **nothing was mutated and the clean tree's exit 0 read as a pass** — a scenario that could no longer fail.
  - `dep-guard/verify.sh` mutation C `sed`'d a literal `pydantic-core==2.46.4` to break the lock-step. Same no-op, but it surfaced as `mutation C: D1 warning not reported` — a stale fixture wearing a checker regression's clothes.

  Both now rewrite *whatever* version is pinned. The floor number inside the expected FAIL message stays literal, because that one genuinely does not move.
- **The ONNX telemetry control is re-verified, not assumed.** A bump that silently dropped `disable_telemetry_events` would have left the env half carrying the whole control with nothing noticing.

---

## Risks to monitor

- **`pydantic` is the widest-reach pin in the tree** — `fastapi`, `chromadb`, `langchain-core`, `langgraph` and `schemas/api.py`'s `extra='forbid', strict=True` models all sit on it. 2.13.4 → 2.13.5 is a patch release, and the full suite is green, but this is the pin where a surprise would show up first. The `ci (3.12)` leg across all three OSes is the thing to watch.
- **`environment.yml` is the surface no sandbox here can dry-run** (no conda/mamba). `pydantic 2.13.5` and `onnxruntime 1.30.0` were both confirmed available — conda-forge lists 2.13.5 as its *latest*, and 1.30.0 ships cp312 wheels for `manylinux_2_28_x86_64/aarch64`, `macosx_14_0_arm64`, `win_amd64/arm64` — but the conda lane itself is verified only by `python-package-conda.yml`.
- **`T13` still reports the conda surface as having no onnxruntime floor** (`info`, pre-existing, unchanged by this PR): it doesn't read `environment.yml`'s `pip:` tail, where the pin actually lives. Not a regression introduced here, but it means the conda lane's floor coverage is asserted by the file and not by the checker.
- **The two fixture fixes make those scenarios stricter, not looser.** If either stops firing again after a future bump, the cause is the install line's *shape* changing, not the version — the scenarios now fail loudly instead of passing vacuously.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments

**ELI5:** two libraries had newer patch releases. Moving them means editing the version number in *four* different files that each describe the install a different way, plus two self-check scripts that had the old numbers typed into them. The interesting part wasn't the bump — it was that two of the repo's own safety tests had the old version numbers hardcoded into their *test setup*, so when the numbers changed, those tests quietly stopped testing anything while still reporting success. Both are fixed to work off whatever version is actually pinned.

**Technical** — what was actually run, not asserted:

| Check | Result |
|---|---|
| `GROK_API_KEY=dummy pytest tests/ -q` | **4780 passed, 78 skipped, 0 failed** (4858 collected, exit 0) |
| `dep-guard/check_deps.py` | 0 failures, 0 warnings — `D1 pydantic==2.13.5 lock-step with pydantic-core==2.46.5`, `D6`/`D9` agree across surfaces |
| `dep-guard/verify.sh` | ALL PASS (mutation C fixed) |
| `verify-deps/check_env_drift.py` | 0 failures, 0 warnings (E1–E7) |
| `verify-deps/verify.sh` | all 24 scenarios PASS |
| `verify-deps/extract_pins.py` | no drift; all four surfaces read 1.30.0 / 2.13.5 |
| `otel-hardening/check_otel.py` | 0 failures, 0 warnings; `T13 onnxruntime pinned 1.30.0 (>= 1.29.0)` on pip + wheel; `T14` ONNX env+API suppression wired |
| `otel-hardening/verify.sh` | ALL PASS (scenario 22 fixed) |
| `invariant-guard/check_invariants.py` | 46 passed, 0 failed |
| `config-guard/check_config.py` | 0 failures (1 pre-existing warning, unchanged) |
| `doc-sync/doc_sync.py` | 0 drift items |
| `pip install --dry-run -r requirements.txt -r requirements-test.txt -c constraints.txt` | exit 0 |
| `pip install --dry-run -e . -c constraints.txt --extra-index-url …/whl/cpu` | exit 0 |
| `pip install --dry-run -r requirements.txt -c constraints.txt` (Docker's step) | exit 0 |
| `pip wheel --no-deps .` | wheel built |
| runtime import check | `pydantic 2.13.5` + `pydantic-core 2.46.5` import clean, strict model constructs; `onnxruntime 1.30.0` exposes `disable_telemetry_events` |
| `conda env create` | **not verified** — no conda/mamba in the sandbox; availability of both versions on conda-forge/PyPI confirmed instead |

**Sweep context:** the full Step 5 run checked 42 packages. 27 are behind latest; 5 CVEs affect current pins (4 chromadb + 1 nltk) and **all 5 were already documented and risk-accepted** — the four chromadb siblings in `.osv-scanner.toml` with per-CVE reachability reasoning, the nltk one in `SECURITY.md` (affected APIs are model-artifact I/O; CyClaw only calls `PorterStemmer.stem()`). All 43 pinned release files are present and unyanked. The remaining 25 gaps are left for explicit review, per this skill's "never bump a runtime pin without approval" guardrail; the largest open question there is `sentence-transformers 5.6.0 → 6.0.1`, which is mechanically feasible but can change embeddings and would need an index rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015weoJyEWnZ29Y2ZTUXcATQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015weoJyEWnZ29Y2ZTUXcATQ)_