### PR TITLE
[infra] - Bump sentence-transformers to 6.0.1 (embeddings verified bit-identical)

### DIFF
--- a/.claude/skills/otel-hardening/check_otel.py
+++ b/.claude/skills/otel-hardening/check_otel.py
@@ -134,7 +134,17 @@ LAST_VERIFIED_VENDOR_PINS = {
     # NEMO_GUARDRAILS_NO_USAGE_STATS and DO_NOT_TRACK (1/true); the usage
     # stats sink is https://events.telemetry.data.nvidia.com/v1.1/events/json.
     "nemoguardrails": "0.24.0",
-    "sentence-transformers": "5.6.0",
+    # 5.6.0 -> 6.0.1 re-verified 2026-09-11 against the installed 6.0.1
+    # source, not just the docs: zero matches for telemetry/analytics/
+    # usage_stats/posthog/segment/mixpanel, and every hardcoded non-hub URL
+    # is an academic citation in a docstring. It reads exactly two env vars,
+    # LOCAL_RANK and CODECARBON_LOG_LEVEL -- the latter only inside an
+    # `importlib.util.find_spec("codecarbon")` guard (__init__.py:51-52) and
+    # only to set a log LEVEL, so it is inert: codecarbon is not installed,
+    # not a 6.0.1 requires-dist entry, and named in no CyClaw manifest.
+    # Category 5 therefore still holds -- all hub traffic flows through
+    # huggingface-hub, which carries its own category-1 and category-3 rows.
+    "sentence-transformers": "6.0.1",
     # Not a pyproject direct pin -- lives in constraints.txt (deepagents
     # transitive). Tracked here because the whole 4-name LANGSMITH_/LANGCHAIN_
     # tracing block defends against exactly this package; verified 2026-08-15
@@ -383,7 +393,7 @@ INVENTORY: tuple[dict[str, object], ...] = (
     {
         "name": "hf model bootstrap fetch", "category": 3, "controls": {},
         "url": "https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables",
-        "versions": "sentence-transformers==5.6.0 / huggingface-hub==1.26.0",
+        "versions": "sentence-transformers==6.0.1 / huggingface-hub==1.26.0",
         "enforcement": "one-time cache-miss download; HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE stay CONDITIONAL "
                        "(set only once the model is confirmed cached -- retrieval/embeddings.py; the real "
                        "in-process gate is local_files_only). Never made unconditional",
@@ -468,10 +478,14 @@ INVENTORY: tuple[dict[str, object], ...] = (
     {
         "name": "sentence-transformers/transformers/torch stack", "category": 5, "controls": {},
         "url": "https://huggingface.co/docs/huggingface_hub/package_reference/environment_variables",
-        "versions": "sentence-transformers==5.6.0; torch==2.13.0+cpu; transformers unbounded transitive",
+        "versions": "sentence-transformers==6.0.1; torch==2.13.0+cpu; transformers unbounded transitive",
         "enforcement": "no own telemetry mechanism; all hub traffic flows through huggingface-hub (its "
                        "category-1 ping row + category-3 bootstrap row)", "scope": "embeddings",
-        "reviewed": "2026-08-27", "evidence": "negative finding; torch OSS wheels carry no telemetry",
+        "reviewed": "2026-09-11",
+        "evidence": "negative finding; torch OSS wheels carry no telemetry. Re-checked on the "
+                    "sentence-transformers 5.6.0 -> 6.0.1 bump: no new egress mechanism, and the hub "
+                    "traffic shape is unchanged -- the only model-cache delta was an empty .no_exist "
+                    "marker for a config 6.0.1 probes for and 5.6.0 does not",
     },
     {
         "name": "core web/runtime libs", "category": 5, "controls": {},

--- a/constraints.txt
+++ b/constraints.txt
@@ -49,7 +49,7 @@ websockets==15.0.1
 langgraph==1.2.9
 langchain-core==1.5.0
 chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; risk accepted ONLY for local/offline air-gapped PersistentClient embedded mode). See SECURITY.md + pip-audit.
-sentence-transformers==5.6.0
+sentence-transformers==6.0.1
 # Transitive of chromadb (which asks only for onnxruntime>=1.14.1) and of
 # fastembed under the guardrails extra. Bounded here rather than left to the
 # resolver because CyClaw's ONNX telemetry control is version-gated:

--- a/environment.yml
+++ b/environment.yml
@@ -71,7 +71,7 @@ dependencies:
   # solve, while a modern exporter ships regenerated protos that work with it.
   # conda-forge currently carries 1.42.1 and 1.43.0 (checked 2026-07-29).
   - opentelemetry-exporter-otlp-proto-grpc>=1.42
-  - sentence-transformers=5.6.0
+  - sentence-transformers=6.0.1
   # pytorch is sentence-transformers' hard transitive and is pinned explicitly
   # here for the same reason constraints.txt pins torch==2.13.0+cpu: post-
   # CVE-2025-32434 safety plus keeping the conda lane testing the same 2.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     # exact pydantic-core (2.46.5), and constraints.txt locks that same version. The
     # dep-guard D1 lock-step check reads the pair from constraints.txt, not pyproject.
     "chromadb==1.5.9",  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md + pip-audit workflow.
-    "sentence-transformers==5.6.0",
+    "sentence-transformers==6.0.1",
     # huggingface_hub and starlette are imported directly by first-party source
     # (retrieval/embeddings.py, gate.py) but were, until now,
     # only implicit transitives of sentence-transformers/fastapi respectively --

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ websockets==15.0.1
 langgraph==1.2.9
 langchain-core==1.5.0
 chromadb==1.5.9  # CVE-2026-45829 (Critical pre-auth RCE; no upstream patch). Risk accepted ONLY for local/offline air-gapped use via PersistentClient (embedded mode, path from config.yaml). No HttpClient, no trust_remote_code. See SECURITY.md + pip-audit workflow.
-sentence-transformers==5.6.0
+sentence-transformers==6.0.1
 huggingface-hub==1.26.0
 starlette==1.3.1
 # Transitive of chromadb, pinned explicitly so this surface carries the same


### PR DESCRIPTION
## Proposed changes

The `verify-deps` Step 5 currency sweep held this one pin back as **the single gap that could change retrieval quality**, so it was decided by measurement rather than by reading release notes.

**Verdict: `6.0.1` is a drop-in, and no reindex is required — both proven, not inferred.**

### Why it needed measuring at all

Three independent safety nets are blind to this change:

1. `embedding_fingerprint()` (`retrieval/embeddings.py:208-225`) stamps only `{model, dim, device}`. A library bump yields a **byte-identical** fingerprint, so `_check_embedding_fingerprint` — which raises `IndexNotFoundError` on mismatch — fires **zero** times.
2. The 4,858-test suite cannot see a behavioural change: `tests/conftest.py` carries no sentence-transformers mock, and every embedding-touching test substitutes 2- or 3-dimensional toy vectors.
3. The only harnesses that run the real library (`tests/ci_rag_smoke.py`, `index-doctor`) assert a `>= min_score` floor and the expected source — so **a ranking shift that keeps the right document above 0.028 passes both**.

Nothing in the repo would have reported a changed embedding function. That is the gap this evaluation closes.

### Method

Two venvs differing in **exactly one package** — `pip freeze` diff is a single line, with numpy/torch/transformers/tokenizers all held — against the **same frozen model weights** (30 files, sha256-verified unchanged), over the **same 67 corpus chunks read back out of the built index** so the input text is provably identical across phases.

The noise floor was measured *first*, so the result is interpretable rather than compared against an arbitrary tolerance:

| Noise floor, within 5.6.0 | max\|Δ\| |
|---|---|
| Same process, re-encoded | `0.000e+00` |
| Separate process | `0.000e+00` |
| **Batch vs single `encode()`** | **`1.043e-07`** (2 of 67 vectors) |

The harness therefore demonstrably resolves 1e-7, and the environment is deterministic.

### Result — every vector bit-identical

| Cross-version 5.6.0 → 6.0.1 | max\|Δ\| | L2 | 1−cos | bit-identical |
|---|---|---|---|---|
| 67 corpus chunks, batch call (index path) | `0.000e+00` | `0.000e+00` | `0.000e+00` | 67/67 |
| 67 corpus chunks, single call (query path) | `0.000e+00` | `0.000e+00` | `0.000e+00` | 67/67 |
| 11 queries, single call | `0.000e+00` | `0.000e+00` | `0.000e+00` | 11/11 |
| 11 queries, batch call | `0.000e+00` | `0.000e+00` | `0.000e+00` | 11/11 |

Both call shapes are measured separately because they are different code paths with different matmul shapes — `get_embedding` → `encode(str, …)` and `get_embeddings_batch` → `encode(list, …)` — and so can disagree *within* one version, as the 1.043e-07 noise row shows. The 11 queries are the 5 `index-doctor` probes, the 4 `ci_rag_smoke` queries, and 6 edge strings chosen where a `tokenizers` floor change would surface: past the truncation boundary, CJK + emoji + combining marks, degenerate whitespace, punctuation-only, single token.

Cosine is reported as `1 − cos` deliberately: every vector is unit-normalised (`normalize_embeddings=True`), so cosine saturates and a 1e-6 perturbation would print as `1.0`. `max|Δ|` and L2 are the metrics with resolution here.

### Ranked-neighbour comparison (the decisive test)

Full cosine ranking of all 67 chunks per gate query, because a probe clearing a 0.028 RRF floor can hide a ranking shift:

| Gate query | Full rank list | top-1 cosine | margin to `min_semantic_score` 0.30 | rank1/rank2 gap |
|---|---|---|---|---|
| 1 | identical | `0.352342427` → unchanged | `+0.052342` → unchanged | unchanged |
| 2 | identical | `0.512351751` → unchanged | `+0.212352` → unchanged | unchanged |
| 3 | identical | `0.544073343` → unchanged | `+0.244073` → unchanged | unchanged |
| 4 | identical | `0.410338998` → unchanged | `+0.110339` → unchanged | unchanged |
| 5 | identical | `0.333487689` → unchanged | `+0.033488` → unchanged | unchanged |

All 5 byte-identical across the **full** 67-entry list, not just the top-k. Query 5's margin is the tightest in the set at `+0.0335` — the one an embedding shift would break first — and it did not move. The rank-1/rank-2 gap is tracked because a shrinking gap is the leading indicator of a flip on a query nobody tested; it is unchanged on all five.

`ci_rag_smoke`'s four semantic scores match to **16 significant figures**. The built artifacts match too: `bm25.json` byte-identical (522,677 bytes), and all 67×384 vectors read back out of the two Chroma collections at `max|Δ| = 0.0`.

### Mixed-version: a proof, not a relief

This is the state an operator actually reaches, because nothing tells them to reindex — `pip install -U` plus a restart *is* the default upgrade path, and the fingerprint reports a match.

- **Index built on 5.6.0, queried by 6.0.1** → 0 failures, 0 warnings.
- **Rollback (index on 6.0.1, queried by 5.6.0)** → 0 failures, 0 warnings.

With bit-identical vectors this is what licenses the "no reindex required" claim. (`ci_rag_smoke.py` calls `build_index()` unconditionally, so it *cannot* perform this test — it necessarily goes through `index-doctor` probe-only.)

### API surface

CyClaw uses **none** of 6.0's five breaking changes — chat-message batching, `similarity` property→method, `trust_remote_code` for custom modules, `CrossEncoder.rank`, `quantize_embeddings` — verified at 0 grep hits each. Its entire surface is `SentenceTransformer(model, cache_folder=, local_files_only=, device=)` plus `encode(…, normalize_embeddings=True[, show_progress_bar=True])`; all five kwargs are still accepted in 6.0.1. The one documented output-affecting caveat, a `Pooling(include_prompt=False)` fix, **cannot apply**: nothing here passes prompts. Every floor 6.0.1 raises was already satisfied, and it does not require `numpy>=2`, so the documented `numpy<2` ceiling is untouched.

**Invariant / Governance Impact:** none of the six invariants, and not I6. No change to `gate.py`, `gate_ops.py`, `gate_auth.py`, `gate_memory.py`, `graph.py`, `mcp_hybrid_server.py`, or any graph edge. `config.yaml`'s `models.embeddings` block is deliberately untouched — the model and `dim` are unchanged, and editing them would invalidate the fingerprint for no reason. `invariant-guard`: 46 passed, 0 failed.

---

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation Update (if none of the other choices apply)

**Optional free-text scope note:** Infrastructure / CI only — one pin across all four install surfaces, plus the otel-hardening registry entries that record it.

---

## Benefits / why

- **Closes the one currency gap that could not be decided on metadata.** The other 25 from the sweep are either deliberate exceptions or still awaiting review; this was the only one whose risk was behavioural.
- **All four surfaces move together:** `requirements.txt`, `constraints.txt`, `pyproject.toml`, `environment.yml` (conda-forge carries 6.0.1 as its *latest*, so the conda lane is not a blocker).
- **`otel-hardening`'s `T5` check did its job and was answered properly, not silenced.** The bump tripped `T5 vendor pin drifted since last verification`, whose contract is the version last verified *against the vendor's actual source*. So the source was re-checked: zero matches for telemetry/analytics/usage_stats/posthog/segment/mixpanel, and every hardcoded non-hub URL is an academic citation in a docstring. It reads exactly two env vars — `LOCAL_RANK`, and `CODECARBON_LOG_LEVEL` only inside an `importlib.util.find_spec("codecarbon")` guard (`__init__.py:51-52`) and only to set a log *level*. That is provably inert: codecarbon is not installed, not a 6.0.1 requires-dist entry, and named in no CyClaw manifest. Category 5 still holds, and the reasoning is now recorded at the pin so the next reader need not re-derive it.
- **Two registry `versions` strings that still said `5.6.0` are corrected** — the same documentation-rot class as the dead E7 exemptions in #1385 and the no-op mutation fixtures in #1389.

---

## Risks to monitor

- **"Bit-identical" is a statement about *this* model on *this* platform.** `all-MiniLM-L6-v2` at `dim` 384 on CPU (`EMBED_DEVICE` is hardcoded `"cpu"`, which is what makes it reproducible). It does not generalise to a different embedding model, and notably not to Apple Silicon MPS — PR #734 records a query's expected top hit moving from rank 3 to outside the top 30 on the MPS path, which is exactly why the device is pinned. An operator who changes `models.embeddings.model` is in different territory entirely.
- **The `.emb_cache` CI key is `hashFiles('config.yaml')` (`ci.yml:722-723`, `:1411-1412`), not the ST pin.** Benign here because the weights are genuinely identical across library versions — sha256-verified, with the only delta an empty `.no_exist` marker — but it means CI reuses cached weights rather than re-resolving from the Hub. Left alone; widening that key is a separate, arguable change.
- **`environment.yml` is verified only by `python-package-conda.yml`** — no conda/mamba in the sandbox. 6.0.1's availability on conda-forge was confirmed instead.
- **The fingerprint gap below is still open.** It did not bite here, but the next embedding-library bump may not be bit-identical, and the blindness is unchanged.

---

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [x] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [ ] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [x] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

---

## Further comments

**ELI5:** a library that turns text into numbers got a new major version. Those numbers *are* the search index, so if they shifted even slightly, every saved index would quietly be wrong — and nothing in CyClaw would have said so, because the staleness check only looks at the model's *name*, not at which version of the library produced the numbers. So instead of trusting the changelog, both versions were run side by side on the same text with the same model files, and the numbers compared digit by digit. They came out exactly the same — not "close enough", identical. The proof that they're identical is also the proof that nobody needs to rebuild their index.

### Known gap, deliberately NOT fixed here

`embedding_fingerprint()` is blind to the library version, so an operator who bumps without reindexing gets **no signal at all**. Harmless for *this* bump because the vectors are identical — and this PR's mixed-version run is the evidence — but it is the wrong default.

It is left as a follow-up by explicit decision, because the obvious fix (adding `sentence_transformers.__version__` to the fingerprint) flows into `_check_embedding_fingerprint`'s unconditional `raise IndexNotFoundError`, turning **every future library bump into a mandatory full reindex behind a 503** — disproportionate for a bump that, as measured here, can be a no-op. The proportionate design is to record the library version as a non-gating key and warn + `audit_log` on mismatch, keeping `{model, dim, device}` fatal. That touches the documented fail-soft 503 contract and `INVARIANTS.md` territory, so it earns its own PR with its own tests rather than riding a pin bump.

A second, smaller gap found in passing: **`doctor.py` never asserts `min_semantic_score`** (0.30, the cosine floor — the threshold an embedding change moves most). Only `tests/ci_rag_smoke.py` does, and that script cannot run the mixed-version case. Also a separate follow-up.

### Verification — what was actually run

| Check | Result |
|---|---|
| `GROK_API_KEY=dummy pytest tests/ -q` under **6.0.1** | **4780 passed, 78 skipped, 0 failed** (4858 collected, exit 0) — identical counts to the 5.6.0 run |
| Vector comparison, 156 vectors across 4 call-shape cells | `max|Δ| = 0.000e+00`, all bit-identical |
| Ranked-neighbour lists, 5 gate queries × 67 chunks | byte-identical, 5/5 |
| `index-doctor` on 5.6.0 (probe-only) | 0 failures, 0 warnings; 67/67 count parity |
| `index-doctor` on 6.0.1 (`--rebuild --baseline`) | 0 failures, 0 warnings; no drift warning |
| `index-doctor` mixed (5.6.0 index / 6.0.1 library) | 0 failures, 0 warnings |
| `index-doctor` rollback (6.0.1 index / 5.6.0 library) | 0 failures, 0 warnings |
| `ci_rag_smoke.py` both phases | exit 0; all 4 semantic scores identical to 16 s.f., all ≥ 0.30 |
| Built artifacts | `bm25.json` byte-identical; 67×384 Chroma vectors `max|Δ| = 0.0`; fingerprints equal |
| Model weights across phases | 30 files sha256-identical; only delta an empty `.no_exist` marker |
| `pip freeze` resolution audit | exactly 1 line moved (sentence-transformers); numpy/torch/transformers/tokenizers held |
| `dep-guard` · `verify-deps` · `otel-hardening` | 0 failures, 0 warnings each (`T5` re-verified, `T13`/`T14` ok) |
| All three `verify.sh` suites | ALL PASS |
| `invariant-guard` · `config-guard` · `doc-sync` | 46/46 · 0 failures · 0 drift |
| `ruff --select F,B,S` and broader set `--ignore E501` | both clean |
| 4 install surfaces (3 pip dry-runs + `pip wheel`) | exit 0 each; wheel built |
| `conda env create` | **not verified** — no conda/mamba in the sandbox; 6.0.1 confirmed on conda-forge instead |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015weoJyEWnZ29Y2ZTUXcATQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015weoJyEWnZ29Y2ZTUXcATQ)_