### PR TITLE
[security] - Disable uvicorn proxy headers in the macOS launcher

### DIFF
--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -182,8 +182,12 @@ else
 fi
 
 # --- start RAG gateway (serves terminal.html) ---
+# Stay on uvicorn so --gate-port / CYCLAW_GATE_PORT still bind. --no-proxy-headers
+# matches gate._serve and the Dockerfile CMD: uvicorn defaults proxy_headers=True
+# with forwarded_allow_ips 127.0.0.1, so a loopback peer could mint a fresh
+# 60/min rate-limit bucket by varying X-Forwarded-For.
 if "$VENV_PY" -c "import uvicorn" 2>/dev/null; then
-  "$VENV_PY" -m uvicorn gate:app --host 127.0.0.1 --port "$GATE_PORT" --log-level warning &
+  "$VENV_PY" -m uvicorn gate:app --host 127.0.0.1 --port "$GATE_PORT" --log-level warning --no-proxy-headers &
 else
   echo "[cyclaw] error: uvicorn not available in $VENV_PY. Install deps first." >&2
   exit 1

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -54,6 +54,29 @@ def test_invoke_cyclaw_home_dir_matches_install_cyclaw() -> None:
     assert invoke_match.group(1) == install_match.group(1)
 
 
+def test_invoke_cyclaw_disables_uvicorn_proxy_headers() -> None:
+    """The Darwin launcher stays on uvicorn so --gate-port still works, but it
+    must pass --no-proxy-headers like gate._serve / the Dockerfile CMD.
+
+    uvicorn's default trusts X-Forwarded-For on loopback and would otherwise
+    let any local process mint a fresh 60/min rate-limit bucket per spoofed IP.
+    """
+    text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
+    spawn = [
+        line
+        for line in text.splitlines()
+        if "uvicorn gate:app" in line and not line.lstrip().startswith("#")
+    ]
+    assert spawn, "invoke-cyclaw.sh no longer spawns uvicorn gate:app"
+    assert all("--no-proxy-headers" in line for line in spawn), (
+        "macOS launcher must pass --no-proxy-headers so X-Forwarded-For cannot "
+        "rewrite the rate-limit client"
+    )
+    assert all("--port" in line for line in spawn), (
+        "--gate-port / CYCLAW_GATE_PORT must still reach uvicorn --port"
+    )
+
+
 def test_invoke_cyclaw_probes_gateway_startup_and_watches_its_pid() -> None:
     """The gateway gets a startup-death probe, and the script must not block
     forever on a wait if the process dies later."""


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-macos-no-proxy-headers`

## Title

`[security] - Disable uvicorn proxy headers in the macOS launcher`

## Proposed changes

The shipped Darwin launcher (`macos/invoke-cyclaw.sh`) still starts the gateway as `uvicorn gate:app`. uvicorn defaults `proxy_headers=True` with `forwarded_allow_ips` resolving to loopback, so any local process can mint a fresh 60/min rate-limit bucket by varying `X-Forwarded-For`.

`gate._serve` already sets `proxy_headers=False`. The Dockerfile CMD already passes `--no-proxy-headers`. Windows `Invoke-CyClaw.ps1` already runs `gate.py` (PR #1367). This PR adds `--no-proxy-headers` to the macOS uvicorn argv and pins it with a source-shape test.

It does **not** switch the launcher to `gate.py`: `--gate-port` / `CYCLAW_GATE_PORT` only bind because uvicorn gets `--port`. `gate.py` `_serve` reads `config.yaml` and does not read `CYCLAW_GATE_PORT`. TLS-on-this-path stays a later PR.

**Invariant / Governance Impact**
- None of the six graph invariants. I6 unchanged (launcher script + test only).
- Rate-limit client identity on the shipped Darwin path now matches `gate._serve` (real peer, not attacker-supplied XFF).
- No `soul.md`, no graph-edge, no bind-address change (still `127.0.0.1`).

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: macOS launcher / rate-limit client identity. Not core graph/gate Python.

## Benefits / why

Closes the XFF rate-limit mint on the primary Darwin launch path without breaking `--gate-port`. Matches the Docker and `gate._serve` contract already tested in `tests/test_gate.py`.

## Risks to monitor

- Operators who *intentionally* put a reverse proxy in front of this launcher and relied on XFF would lose that rewrite. CyClaw is loopback-only and sits behind no reverse proxy; that is the documented threat-model position.
- `--gate-port` still works only because this stays on uvicorn. Do not "complete" this by switching to `gate.py` without wiring `CYCLAW_GATE_PORT` into `_serve`.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_macos_scripts.py::test_invoke_cyclaw_disables_uvicorn_proxy_headers tests/test_macos_scripts.py::test_invoke_cyclaw_home_dir_matches_install_cyclaw tests/test_macos_scripts.py::test_invoke_cyclaw_probes_gateway_startup_and_watches_its_pid tests/test_macos_scripts.py::test_invoke_cyclaw_loads_persisted_api_key_from_dotenv tests/test_macos_launchagent_template_contract.py::test_invoke_launcher_validates_ports_before_use` — exit 0
- `python -m ruff check tests/test_macos_scripts.py --select E,F,I,B,C4,UP,S` — exit 0
- `python C:\Users\cgrady\.grok\githooks\cyclaw\verify_ci_emulation.py` (this HEAD)

## Merge order

- **This PR:** P1 of 2 (merge first)
- **Full stack:** P1 (this) → P2 `grok/cyclaw-optimize-harness-lock-reclaim` (harness-optimizer lock reclaim)
- **Topology:** parallel (no shared files)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@f39bc59b`
