### PR TITLE
[fix] - Guard harness-optimizer lock reclaim against TOCTOU

### DIFF
--- a/agentic/harness_optimizer/patching.py
+++ b/agentic/harness_optimizer/patching.py
@@ -39,6 +39,69 @@ _SLUG_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 _write_lock = threading.Lock()
 
 
+def _reclaim_guard_path(lock_dir: Path) -> Path:
+    return lock_dir.with_name(lock_dir.name + ".reclaim.d")
+
+
+def _reclaim_artifact_lock(lock_dir: Path) -> bool:
+    """Reclaim one stale lock without deleting a concurrent winner's lock.
+
+    Same atomic-mkdir reclaim-guard pattern as ``agentic.registry._reclaim_registry_lock``.
+    A bare ``rmtree`` + ``mkdir`` lets two reclaimers both pass ``_can_reclaim_lock``
+    and the later ``rmtree`` remove the winner's lock while it is writing artifacts.
+    """
+    reclaim_guard = _reclaim_guard_path(lock_dir)
+    try:
+        reclaim_guard.mkdir()
+    except FileExistsError:
+        return False
+    except OSError as exc:
+        # FileExistsError is "another reclaimer won". Disk-full / EACCES here
+        # is not contention -- returning False would lie as "another accept is
+        # in progress". Fail closed as a typed agentic error.
+        raise AgenticError(
+            "could not create harness-optimizer reclaim guard",
+            details={
+                "lock_dir": str(lock_dir),
+                "guard": str(reclaim_guard),
+                "errno": getattr(exc, "errno", None),
+            },
+        ) from exc
+
+    try:
+        try:
+            age = time.time() - lock_dir.stat().st_mtime
+        except FileNotFoundError:
+            # The prior owner released between our failed acquire and guard win.
+            age = 0.0
+            lock_was_present = False
+        except OSError:
+            return False
+        else:
+            lock_was_present = True
+
+        if lock_was_present:
+            if not _can_reclaim_lock(lock_dir, age):
+                return False
+            shutil.rmtree(lock_dir)
+
+        try:
+            lock_dir.mkdir()
+        except FileExistsError:
+            # A normal acquirer won after the stale directory was removed. Its
+            # fresh lock must remain intact.
+            return False
+        _write_lock_token(lock_dir)
+        return True
+    except OSError:
+        return False
+    finally:
+        try:
+            reclaim_guard.rmdir()
+        except OSError:
+            pass
+
+
 def _acquire_artifact_lock(lock_dir: Path) -> None:
     """Acquire a cross-process write lock, or raise ``AgenticError``.
 
@@ -55,19 +118,8 @@ def _acquire_artifact_lock(lock_dir: Path) -> None:
     except FileExistsError:
         # Lock is already held; fall through to the stale-age check below.
         pass
-    try:
-        age = time.time() - lock_dir.stat().st_mtime
-    except OSError:
-        age = 0.0
-    if _can_reclaim_lock(lock_dir, age):
-        try:
-            shutil.rmtree(lock_dir, ignore_errors=True)
-            lock_dir.mkdir(parents=True)
-            _write_lock_token(lock_dir)
-            return
-        except OSError:
-            # Another process won the reclaim race; fall through and refuse below.
-            pass
+    if _reclaim_artifact_lock(lock_dir):
+        return
     raise AgenticError(
         "another harness-optimizer accept is in progress for this candidate",
         details={"lock_dir": str(lock_dir)},

--- a/tests/test_agentic_harness_optimizer.py
+++ b/tests/test_agentic_harness_optimizer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import time
 from pathlib import Path
 
@@ -435,3 +436,58 @@ def test_artifact_lock_refuses_live_owner(tmp_path: Path) -> None:
 
     with pytest.raises(AgenticError, match="another harness-optimizer accept"):
         _acquire_artifact_lock(lock)
+
+
+def test_artifact_lock_serializes_stale_reclaim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two reclaimers must not rmtree a winner's freshly acquired lock."""
+    lock = tmp_path / "artifact.lock.d"
+    lock.mkdir()
+    token = {"pid": 999999, "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+    real_rmtree = shutil.rmtree
+    second_attempted = False
+
+    def _interleaved_rmtree(path: Path, *args: object, **kwargs: object) -> None:
+        nonlocal second_attempted
+        second_attempted = True
+        with pytest.raises(AgenticError, match="another harness-optimizer accept"):
+            _acquire_artifact_lock(lock)
+        assert lock.exists(), "a competing reclaimer must not delete this lock"
+        real_rmtree(path)
+
+    monkeypatch.setattr("agentic.harness_optimizer.patching.shutil.rmtree", _interleaved_rmtree)
+    _acquire_artifact_lock(lock)
+
+    assert second_attempted is True
+    assert _is_lock_owner(lock) is True
+    assert not lock.with_name(lock.name + ".reclaim.d").exists()
+    _release_artifact_lock(lock)
+
+
+def test_artifact_lock_reclaim_guard_mkdir_oserror_is_agentic_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Permission/ENOSPC on the reclaim-guard mkdir must be AgenticError,
+    not a raw OSError and not the 'another accept is in progress' lie.
+    """
+    lock = tmp_path / "artifact.lock.d"
+    lock.mkdir()
+    token = {"pid": 999999, "started_at": time.time() - 9999}
+    lock.joinpath("owner.json").write_text(json.dumps(token), encoding="utf-8")
+    old = time.time() - (_LOCK_STALE_SEC + 60)
+    os.utime(lock, (old, old))
+
+    real_mkdir = Path.mkdir
+
+    def _mkdir(self: Path, *args: object, **kwargs: object) -> None:
+        if str(self).endswith(".reclaim.d"):
+            raise PermissionError("denied")
+        real_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", _mkdir)
+    with pytest.raises(AgenticError, match="reclaim guard") as excinfo:
+        _acquire_artifact_lock(lock)
+    assert excinfo.value.code == "AGENTIC_ERROR"
+    assert not lock.with_name(lock.name + ".reclaim.d").exists()


### PR DESCRIPTION
## Branch naming (required for agent-opened PRs)

`grok/cyclaw-optimize-harness-lock-reclaim`

## Title

`[fix] - Guard harness-optimizer lock reclaim against TOCTOU`

## Proposed changes

`agentic/harness_optimizer/patching.py` reclaimed a stale artifact lock with a bare `shutil.rmtree` + `mkdir`. Two reclaimers can both pass `_can_reclaim_lock` and the later `rmtree` can delete the winner's lock while it is writing artifacts.

`agentic.registry._reclaim_registry_lock` already serializes reclaim with an atomic `.reclaim.d` mkdir, re-checks ownership, and fails closed on `OSError` (not "another apply is in progress"). This PR copies that **pattern** into `_reclaim_artifact_lock` (raises `AgenticError`, not `SkillRegistryError`) and adds the two registry-equivalent tests: interleaved reclaim, and reclaim-guard `mkdir` PermissionError.

No new shared abstraction. I6: `agentic/` stays out of `gate.py` / `graph.py` / MCP.

**Invariant / Governance Impact**
- None of the six graph invariants. I6 preserved (`agentic/` remains OOB).
- Harness-optimizer accept stays default-off and human-gated; this only makes the existing lock honest under concurrent reclaim.

## Types of changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation Update
- [ ] Invariant / Governance refinement

Optional free-text scope note: Out-of-band agentic/harness_optimizer lock.

## Benefits / why

A crashed-run lock can be reclaimed without a second reclaimer clobbering the process that already won. Same race the skills registry already closed.

## Risks to monitor

- A leftover `.reclaim.d` after a crash still fail-closes (same as registry). Operator hint is on the "another accept is in progress" path.
- `ignore_errors=True` was dropped from reclaim `rmtree` so a failed delete cannot look like a successful steal. If a locked-file OS keeps the dir, reclaim returns False and the accept is refused — fail closed.

## Checklist

- [x] Read latest architecture / SECURITY.md as needed
- [x] Six invariants + I6 isolation preserved
- [x] cyclaw-sandbox + CI emulation stamp written (`verify_ci_emulation.py`)
- [x] Draft PR only; no push to `main`

## Verify

- `GROK_API_KEY=dummy python -m pytest tests/test_agentic_harness_optimizer.py tests/test_agentic_harness_phase679.py::test_stale_candidate_lock_is_reclaimed -q --tb=short` — 31 passed, 2 skipped, exit 0
- `python -m ruff check agentic/harness_optimizer/patching.py tests/test_agentic_harness_optimizer.py --select E,F,I,B,C4,UP,S` — exit 0
- `python C:\Users\cgrady\.grok\githooks\cyclaw\verify_ci_emulation.py` (this HEAD)

## Merge order

- **This PR:** P2 of 2 (merge after P1)
- **Full stack:** P1 #1393 `grok/cyclaw-optimize-macos-no-proxy-headers` → P2 (this)
- **Topology:** parallel (no shared files; both `base: main`)

## Base

- GitHub base branch: `main`
- Forked from: `origin/main@f39bc59b`
