### PR TITLE
[rag] - Block CI on groundedness retrieval hit@K/MRR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -727,8 +727,9 @@ jobs:
       - name: RAG Query Smoke (ChromaDB + BM25 + RRF)
         shell: bash
         run: |
-          # Validates full retrieval path against committed corpus.
-          # Fails CI if min_score gate or hybrid fusion broken.
+          # Validates full retrieval path against committed corpus, then
+          # hit@5/Recall@5/MRR on tests/fixtures/groundedness (no LLM).
+          # Fails CI if min_score gate, hybrid fusion, or those floors break.
           # (Unit tests + coverage run in the next step.)
           python -m tests.ci_rag_smoke
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # `tests/` — the CyClaw test suite
 
-Pytest suite for this directory (207 `test_*.py` files, auto-collected
+Pytest suite for this directory (208 `test_*.py` files, auto-collected
 via `testpaths = ["tests"]` in `pyproject.toml`). Test trees outside `tests/` —
 notably `tools/lora_finetune/tests/`, whose CI is `.github/workflows/lora-finetune.yml` —
 are NOT collected by `pytest tests/`; see `CLAUDE.md` §8. Everything external is mocked
@@ -57,7 +57,7 @@ test files are auto-discovered and need neither.
 | `judge_eval.py` | Default-off 24-case groundedness evaluator. Builds an isolated real Chroma/BM25 index from tracked synthetic fixtures and sends public-safe evaluation data to Claude only after both live gates pass. |
 | `TEST_SUITE_AUDIT.md`, `VERIFICATION_REPORT_3.12.md` | Point-in-time audit reports, kept beside the suite they audited. |
 | `apipsTest.ps1`, `cmd2index.bat` | Windows-side manual helpers; not collected by pytest. |
-| `nemo_runtime/` | NeMo-guardrails runtime tests plus their own harness (`network_jail.py`, `mock_openai.py`); its two `test_*.py` files are part of the 207. |
+| `nemo_runtime/` | NeMo-guardrails runtime tests plus their own harness (`network_jail.py`, `mock_openai.py`); its two `test_*.py` files are part of the 208. |
 | `executor_sandbox_double.py`, `spend_live_probe.py` | Helper doubles/probes, not `test_*`-named, so not collected. |
 
 ## Conventions that bite

--- a/tests/ci_rag_smoke.py
+++ b/tests/ci_rag_smoke.py
@@ -28,7 +28,10 @@ gate/graph unit tests with a mocked LLM.
 Exit non-zero on any failure so the CI step goes red on a real retrieval regression.
 """
 
+import statistics
 import sys
+import tempfile
+from collections.abc import Sequence
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -39,6 +42,15 @@ import yaml  # noqa: E402
 
 from retrieval.indexer import build_index  # noqa: E402
 from retrieval.hybrid_search import HybridRetriever  # noqa: E402
+from tests import judge_eval  # noqa: E402
+
+# K matches the live eval plane's evidence window. Floors are for this
+# synthetic 24-case fixture (20 scored; 4 out-of-corpus skipped). Tighten
+# from a measured origin/main run, do not copy faithfulness 0.80 here.
+K = judge_eval.MAX_EVIDENCE_HITS
+MIN_HIT_AT_K = 1.0
+MIN_RECALL_AT_K = 1.0
+MIN_MRR = 0.5
 
 # (query, expected_source_substring) — each answerable by data/corpus/cyclaw_overview.md.
 # Phrased near-verbatim to corpus content to clear the min_score gate reliably in CI.
@@ -52,6 +64,94 @@ QUERIES = [
         "cyclaw_overview",
     ),
 ]
+
+
+def unique_source_stems(hits: Sequence[object], k: int) -> list[str]:
+    """First-seen Path(hit.source).stem, capped at k unique documents."""
+    stems: list[str] = []
+    for hit in hits:
+        stem = Path(str(getattr(hit, "source", ""))).stem
+        if not stem or stem in stems:
+            continue
+        stems.append(stem)
+        if len(stems) >= k:
+            break
+    return stems
+
+
+def hit_at_k(ranked: Sequence[str], expected: frozenset[str], k: int) -> float | None:
+    if not expected:
+        return None
+    return 1.0 if expected.intersection(ranked[:k]) else 0.0
+
+
+def recall_at_k(ranked: Sequence[str], expected: frozenset[str], k: int) -> float | None:
+    if not expected:
+        return None
+    return len(expected.intersection(ranked[:k])) / len(expected)
+
+
+def mean_reciprocal_rank(ranked: Sequence[str], expected: frozenset[str]) -> float | None:
+    if not expected:
+        return None
+    for index, stem in enumerate(ranked, start=1):
+        if stem in expected:
+            return 1.0 / index
+    return 0.0
+
+
+def _mean(values: list[float]) -> float:
+    return statistics.fmean(values) if values else 0.0
+
+
+def groundedness_retrieval_metrics(retriever: HybridRetriever) -> tuple[int, float, float, float]:
+    """Return (n_scored, hit@K, Recall@K, MRR) over cases with expected sources."""
+    hits_out: list[float] = []
+    recalls: list[float] = []
+    mrrs: list[float] = []
+    for case in judge_eval.load_cases():
+        expected = frozenset(case.expected_source_ids)
+        if not expected:
+            continue
+        ranked = unique_source_stems(retriever.hybrid_search(case.query), K)
+        hit = hit_at_k(ranked, expected, K)
+        rec = recall_at_k(ranked, expected, K)
+        mrr = mean_reciprocal_rank(ranked, expected)
+        assert hit is not None and rec is not None and mrr is not None
+        hits_out.append(hit)
+        recalls.append(rec)
+        mrrs.append(mrr)
+    return len(hits_out), _mean(hits_out), _mean(recalls), _mean(mrrs)
+
+
+def _run_groundedness_retrieval_gate() -> int:
+    print("\n=== Groundedness retrieval metrics (isolated fixture index, no LLM) ===")
+    scored_expected = sum(1 for case in judge_eval.load_cases() if case.expected_source_ids)
+    with tempfile.TemporaryDirectory(prefix="cyclaw-groundedness-retr-") as tmp:
+        config_path, _, _ = judge_eval.build_eval_index(Path(tmp))
+        retriever = HybridRetriever(str(config_path))
+        n_scored, hit, recall, mrr = groundedness_retrieval_metrics(retriever)
+    print(f"  scored_cases: {n_scored} (expected {scored_expected})")
+    print(f"  hit@{K}:      {hit:.4f}  (floor {MIN_HIT_AT_K})")
+    print(f"  recall@{K}:   {recall:.4f}  (floor {MIN_RECALL_AT_K})")
+    print(f"  MRR:        {mrr:.4f}  (floor {MIN_MRR})")
+    if n_scored != scored_expected:
+        print(f"FAIL: expected {scored_expected} cases with source labels, got {n_scored}")
+        return 1
+    failed = False
+    if hit < MIN_HIT_AT_K:
+        print(f"FAIL: hit@{K} {hit:.4f} < {MIN_HIT_AT_K}")
+        failed = True
+    if recall < MIN_RECALL_AT_K:
+        print(f"FAIL: recall@{K} {recall:.4f} < {MIN_RECALL_AT_K}")
+        failed = True
+    if mrr < MIN_MRR:
+        print(f"FAIL: MRR {mrr:.4f} < {MIN_MRR}")
+        failed = True
+    if failed:
+        return 1
+    print("  PASS: groundedness retrieval floors held")
+    return 0
 
 
 def main() -> int:
@@ -110,7 +210,7 @@ def main() -> int:
         return 1
 
     print(f"\nAll {len(QUERIES)} real RAG queries passed (vault hits above the {min_score} gate)")
-    return 0
+    return _run_groundedness_retrieval_gate()
 
 
 if __name__ == "__main__":

--- a/tests/ci_rag_smoke.py
+++ b/tests/ci_rag_smoke.py
@@ -127,10 +127,15 @@ def groundedness_retrieval_metrics(retriever: HybridRetriever) -> tuple[int, flo
 def _run_groundedness_retrieval_gate() -> int:
     print("\n=== Groundedness retrieval metrics (isolated fixture index, no LLM) ===")
     scored_expected = sum(1 for case in judge_eval.load_cases() if case.expected_source_ids)
-    with tempfile.TemporaryDirectory(prefix="cyclaw-groundedness-retr-") as tmp:
+    # ignore_cleanup_errors: Windows Chroma keeps data_level0.bin mapped after
+    # search; rmtree then raises WinError 32. Metrics are already computed.
+    with tempfile.TemporaryDirectory(
+        prefix="cyclaw-groundedness-retr-", ignore_cleanup_errors=True
+    ) as tmp:
         config_path, _, _ = judge_eval.build_eval_index(Path(tmp))
         retriever = HybridRetriever(str(config_path))
         n_scored, hit, recall, mrr = groundedness_retrieval_metrics(retriever)
+        del retriever
     print(f"  scored_cases: {n_scored} (expected {scored_expected})")
     print(f"  hit@{K}:      {hit:.4f}  (floor {MIN_HIT_AT_K})")
     print(f"  recall@{K}:   {recall:.4f}  (floor {MIN_RECALL_AT_K})")

--- a/tests/ci_rag_smoke.py
+++ b/tests/ci_rag_smoke.py
@@ -66,19 +66,6 @@ QUERIES = [
 ]
 
 
-def unique_source_stems(hits: Sequence[object], k: int) -> list[str]:
-    """First-seen Path(hit.source).stem, capped at k unique documents."""
-    stems: list[str] = []
-    for hit in hits:
-        stem = Path(str(getattr(hit, "source", ""))).stem
-        if not stem or stem in stems:
-            continue
-        stems.append(stem)
-        if len(stems) >= k:
-            break
-    return stems
-
-
 def hit_at_k(ranked: Sequence[str], expected: frozenset[str], k: int) -> float | None:
     if not expected:
         return None
@@ -113,7 +100,9 @@ def groundedness_retrieval_metrics(retriever: HybridRetriever) -> tuple[int, flo
         expected = frozenset(case.expected_source_ids)
         if not expected:
             continue
-        ranked = unique_source_stems(retriever.hybrid_search(case.query), K)
+        # Match judge_eval's first K chunks; deduplication would admit later
+        # sources and inflate reciprocal rank when one document has many chunks.
+        ranked = [Path(hit.source).stem for hit in retriever.hybrid_search(case.query)[:K]]
         hit = hit_at_k(ranked, expected, K)
         rec = recall_at_k(ranked, expected, K)
         mrr = mean_reciprocal_rank(ranked, expected)

--- a/tests/fixtures/groundedness/README.md
+++ b/tests/fixtures/groundedness/README.md
@@ -9,3 +9,10 @@ The corpus names, organizations, measurements, and relationships are synthetic.
 Each case declares expected claims, forbidden claims, and expected source IDs.
 Live reports store only case IDs, scores, reason codes, and source IDs; they do
 not persist queries, answers, evidence excerpts, or claim text.
+
+`python -m tests.ci_rag_smoke` (required CI) also builds an **isolated** index
+from this corpus and fails if macro hit@5 / Recall@5 / MRR on the 20
+source-labeled cases drop below floors in `tests/ci_rag_smoke.py`. The four
+`out_of_corpus` cases are skipped (no relevant documents). No LLM. Do not
+point this fixture at `data/corpus/` or a production index.
+

--- a/tests/fixtures/groundedness/README.md
+++ b/tests/fixtures/groundedness/README.md
@@ -15,4 +15,6 @@ from this corpus and fails if macro hit@5 / Recall@5 / MRR on the 20
 source-labeled cases drop below floors in `tests/ci_rag_smoke.py`. The four
 `out_of_corpus` cases are skipped (no relevant documents). No LLM. Do not
 point this fixture at `data/corpus/` or a production index.
-
+Metrics use the first five retrieved chunks, matching the evaluator's hit
+window. Recall counts each expected source once; reciprocal rank uses the
+first matching chunk's original position, without deduplicating the ranking.

--- a/tests/test_retrieval_metrics.py
+++ b/tests/test_retrieval_metrics.py
@@ -1,0 +1,44 @@
+"""Pure retrieval-metric helpers used by tests.ci_rag_smoke. No Chroma, no LLM."""
+
+from __future__ import annotations
+
+from tests.ci_rag_smoke import hit_at_k, mean_reciprocal_rank, recall_at_k, unique_source_stems
+
+
+class _Hit:
+    def __init__(self, source: str) -> None:
+        self.source = source
+
+
+def test_unique_source_stems_dedupes_chunks_and_caps_k() -> None:
+    hits = [
+        _Hit("aurora_harbor.md"),
+        _Hit("/tmp/aurora_harbor.md"),
+        _Hit("cedar_transit.md"),
+        _Hit("lumen_library.md"),
+    ]
+    assert unique_source_stems(hits, k=2) == ["aurora_harbor", "cedar_transit"]
+
+
+def test_empty_expected_is_skipped() -> None:
+    ranked = ["aurora_harbor"]
+    empty: frozenset[str] = frozenset()
+    assert hit_at_k(ranked, empty, 5) is None
+    assert recall_at_k(ranked, empty, 5) is None
+    assert mean_reciprocal_rank(ranked, empty) is None
+
+
+def test_hit_recall_mrr_on_two_source_case() -> None:
+    ranked = ["cedar_transit", "aurora_harbor", "nova_farm"]
+    expected = frozenset({"aurora_harbor", "quartz_energy"})
+    assert hit_at_k(ranked, expected, 5) == 1.0
+    assert recall_at_k(ranked, expected, 5) == 0.5
+    assert mean_reciprocal_rank(ranked, expected) == 0.5
+
+
+def test_miss_is_zero() -> None:
+    ranked = ["nova_farm"]
+    expected = frozenset({"aurora_harbor"})
+    assert hit_at_k(ranked, expected, 5) == 0.0
+    assert recall_at_k(ranked, expected, 5) == 0.0
+    assert mean_reciprocal_rank(ranked, expected) == 0.0

--- a/tests/test_retrieval_metrics.py
+++ b/tests/test_retrieval_metrics.py
@@ -2,22 +2,19 @@
 
 from __future__ import annotations
 
-from tests.ci_rag_smoke import hit_at_k, mean_reciprocal_rank, recall_at_k, unique_source_stems
+from types import SimpleNamespace
+from unittest.mock import create_autospec
+
+import pytest
+
+from retrieval.hybrid_search import HybridRetriever
+from tests import ci_rag_smoke, judge_eval
+from tests.ci_rag_smoke import hit_at_k, mean_reciprocal_rank, recall_at_k
 
 
 class _Hit:
     def __init__(self, source: str) -> None:
         self.source = source
-
-
-def test_unique_source_stems_dedupes_chunks_and_caps_k() -> None:
-    hits = [
-        _Hit("aurora_harbor.md"),
-        _Hit("/tmp/aurora_harbor.md"),
-        _Hit("cedar_transit.md"),
-        _Hit("lumen_library.md"),
-    ]
-    assert unique_source_stems(hits, k=2) == ["aurora_harbor", "cedar_transit"]
 
 
 def test_empty_expected_is_skipped() -> None:
@@ -42,3 +39,23 @@ def test_miss_is_zero() -> None:
     assert hit_at_k(ranked, expected, 5) == 0.0
     assert recall_at_k(ranked, expected, 5) == 0.0
     assert mean_reciprocal_rank(ranked, expected) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("sources", "expected_metrics"),
+    [
+        (["noise.md"] * 5 + ["expected.md"], (1, 0.0, 0.0, 0.0)),
+        (["noise.md"] * 2 + ["expected.md"], (1, 1.0, 1.0, 1 / 3)),
+        (["expected.md"] * 5, (1, 1.0, 1.0, 1.0)),
+    ],
+)
+def test_metrics_respect_chunk_window_and_rank(
+    monkeypatch: pytest.MonkeyPatch,
+    sources: list[str],
+    expected_metrics: tuple[int, float, float, float],
+) -> None:
+    case = SimpleNamespace(query="fixture question", expected_source_ids=("expected",))
+    monkeypatch.setattr(judge_eval, "load_cases", lambda: [case])
+    retriever = create_autospec(HybridRetriever, instance=True)
+    retriever.hybrid_search.return_value = [_Hit(source) for source in sources]
+    assert ci_rag_smoke.groundedness_retrieval_metrics(retriever) == expected_metrics


### PR DESCRIPTION
## Proposed changes

Partial [#1398](https://github.com/cgfixit/CyClaw/issues/1398) (PR A of the collapsed eval plan). Extends `python -m tests.ci_rag_smoke` — same CI step, still **not** named `test_*`.

After the existing 4 `data/corpus` vault-hit queries, the smoke builds an **isolated** index from `tests/fixtures/groundedness/` via `judge_eval.build_eval_index` (temp dir, not `logs/evals/`, not `data/corpus/`) and fails if macro **hit@5 / Recall@5 / MRR** on the 20 source-labeled cases drop below floors in `tests/ci_rag_smoke.py`. The 4 `out_of_corpus` cases are skipped.

No `evals/` directory. No LLM. No `CYCLAW_EVAL_LIVE`. `min_score` and Chroma pins unchanged.

**Invariant / Governance Impact:** none of I1–I6. Retrieval-only test/CI. `judge_eval.py` remains unimported by `gate.py` / `graph.py`. Topology, fallback, audit, soul, I6 isolation unchanged.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Benefits / why

CI can now fail a real hybrid-retrieval regression on a labeled 6-doc fixture instead of only four near-verbatim overview queries. Reuses the existing groundedness schema instead of a second `evals/` stack.

## Risks to monitor

- Floors remain hit@5=1.0, Recall@5=1.0, MRR=0.5. The real offline smoke measured all three metrics at 1.0 locally, and the RAG smoke passed on Ubuntu, macOS, and Windows at `7751b433`. These floors cover this synthetic fixture, not general retrieval quality.
- Windows Chroma keeps index files mapped, so temporary-index deletion uses best-effort cleanup; leftover fixture files may remain until runner cleanup.
- `build_eval_index` sets `HF_HUB_OFFLINE=1` after the overview smoke; the embedding cache must already be warm (existing CI cache step).

## Checklist

- [x] I have read `INVARIANTS.md` and `AGENTS.md`
- [x] This change preserves I6 process isolation and the write gates (N/A — tests/CI only)
- [x] Quality bar: exact CI test/coverage command passed locally (89.05%, unchanged 80% floor); final focused retrieval/evaluator/hygiene tests 40 passed; blocking and broader Ruff passed; invariant-guard 46/46; doc-sync 0 drift; real offline `python -m tests.ci_rag_smoke` passed. Advisory mypy reports missing PyYAML stubs in the local environment.
- [x] No new external network dependencies
- [x] `confirm` is never defaulted (untouched)
- [x] `tests/fixtures/groundedness/README.md` updated
- [x] Commit title uses `[rag]`
- [x] PR body checked with `scripts/check-pr-template.sh`

## Further comments

ELI5: we already had 24 labeled questions on fake harbor/transit docs. CI now checks that search still finds the right fake docs, without calling a chat model.


Review fixes: corrected the recursive test-file count (207 to 208), handled Windows Chroma cleanup, and scored only the first five chunks while retaining original chunk positions for MRR. Regression tests prove that a relevant sixth chunk earns no credit and duplicate earlier chunks do not improve reciprocal rank. Main baseline: 4,790 tests passed, 78 skipped with native permissions. No metric or coverage floors were lowered.
