### PR TITLE
[security] - Disable uvicorn proxy headers on remaining harness spawners

### DIFF
--- a/.claude/skills/CyClaw-Sandbox/run_full_verification.py
+++ b/.claude/skills/CyClaw-Sandbox/run_full_verification.py
@@ -522,11 +522,13 @@ def phase_build_corpus() -> PhaseResult:
     phase.checks.append(Check("corpus_files_written", True))
 
     # Build BM25 index
+    # chunks is initialized here so a BM25 import failure cannot leave the
+    # later Chroma loop reading an unbound name (reproduced 2026-09-13).
+    chunks = []
     try:
         from rank_bm25 import BM25Okapi
         from retrieval.stemmer import tokenize_and_stem
 
-        chunks = []
         tokenized = []
         for fname in files:
             text = (corpus_dir / fname).read_text()

--- a/.claude/skills/CyClaw-Sandbox/smoke.sh
+++ b/.claude/skills/CyClaw-Sandbox/smoke.sh
@@ -73,7 +73,7 @@ fi
 
 echo "[smoke] Starting server on :$PORT ..."
 GROK_API_KEY="$GROK_API_KEY" CYCLAW_API_KEY="$CYCLAW_API_KEY" \
-  "$PYTHON" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" > "$LOG" 2>&1 &  # DevSkim: ignore DS162092
+  "$PYTHON" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" --no-proxy-headers > "$LOG" 2>&1 &  # DevSkim: ignore DS162092
 SERVER_PID=$!
 
 for i in $(seq 1 30); do

--- a/.claude/skills/CyClaw-Sandbox/verify.sh
+++ b/.claude/skills/CyClaw-Sandbox/verify.sh
@@ -155,7 +155,7 @@ fi
 if [ ! -f index/bm25.json ]; then
   "$VPY" -m retrieval.indexer > /tmp/cyclaw-verify-index.txt 2>&1 || true
 fi
-"$VPY" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" > "$SERVER_LOG" 2>&1 &  # DevSkim: ignore DS162092 — loopback-only by design
+"$VPY" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" --no-proxy-headers > "$SERVER_LOG" 2>&1 &  # DevSkim: ignore DS162092 — loopback-only by design
 SERVER_PID=$!
 
 UP=0

--- a/.codex/skills/Cyclaw-Sandbox/run_full_verification.py
+++ b/.codex/skills/Cyclaw-Sandbox/run_full_verification.py
@@ -550,6 +550,9 @@ def phase_build_corpus() -> PhaseResult:
     phase.checks.append(Check("corpus_files_written", True))
 
     chunks = []
+    # tokenized is paired with chunks in the Chroma zip below; initialize it
+    # here so a BM25 failure cannot UnboundLocalError that loop.
+    tokenized = []
 
     # Build BM25 index using the same public tokenizer as retrieval/indexer.py.
     try:

--- a/.codex/skills/Cyclaw-Sandbox/smoke.sh
+++ b/.codex/skills/Cyclaw-Sandbox/smoke.sh
@@ -73,7 +73,7 @@ fi
 
 echo "[smoke] Starting server on :$PORT ..."
 GROK_API_KEY="$GROK_API_KEY" CYCLAW_API_KEY="$CYCLAW_API_KEY" \
-  "$PYTHON" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" > "$LOG" 2>&1 &  # DevSkim: ignore DS162092
+  "$PYTHON" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" --no-proxy-headers > "$LOG" 2>&1 &  # DevSkim: ignore DS162092
 SERVER_PID=$!
 
 for i in $(seq 1 30); do

--- a/.codex/skills/Cyclaw-Sandbox/verify.sh
+++ b/.codex/skills/Cyclaw-Sandbox/verify.sh
@@ -155,7 +155,7 @@ fi
 if [ ! -f index/bm25.json ]; then
   "$VPY" -m retrieval.indexer > /tmp/cyclaw-verify-index.txt 2>&1 || true
 fi
-"$VPY" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" > "$SERVER_LOG" 2>&1 &  # DevSkim: ignore DS162092 — loopback-only by design
+"$VPY" -m uvicorn gate:app --host 127.0.0.1 --port "$PORT" --no-proxy-headers > "$SERVER_LOG" 2>&1 &  # DevSkim: ignore DS162092 — loopback-only by design
 SERVER_PID=$!
 
 UP=0

--- a/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
+++ b/.codex/skills/cyclaw-sandbox-test/scripts/run_sandbox_test.py
@@ -540,7 +540,7 @@ def main() -> int:
 
         server = _start_process(
             "uvicorn",
-            [str(py), "-m", "uvicorn", "gate:app", "--host", "127.0.0.1", "--port", "8787", "--log-level", "warning"],
+            [str(py), "-m", "uvicorn", "gate:app", "--host", "127.0.0.1", "--port", "8787", "--no-proxy-headers", "--log-level", "warning"],
             repo,
             env,
             server_log,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -821,7 +821,7 @@ jobs:
           MOCK_PID="$LAST_PID"
           wait_for_endpoint "mock Ollama" "http://127.0.0.1:11434/api/tags" "$MOCK_PID" || { on_failure; exit 1; }
 
-          start_process "gateway" python -m uvicorn gate:app --host 127.0.0.1 --port 8787
+          start_process "gateway" python -m uvicorn gate:app --host 127.0.0.1 --port 8787 --no-proxy-headers
           GATEWAY_PID="$LAST_PID"
           wait_for_endpoint "gateway" "http://127.0.0.1:8787/health" "$GATEWAY_PID" || { on_failure; exit 1; }
 
@@ -893,7 +893,7 @@ jobs:
             Wait-CyClawEndpoint -Name "mock Ollama" -Uri "http://127.0.0.1:11434/api/tags" -Process $mock
 
             $gateway = Start-CyClawProcess -Name "gateway" -WorkingDirectory $env:GITHUB_WORKSPACE -Arguments @(
-              "-m", "uvicorn", "gate:app", "--host", "127.0.0.1", "--port", "8787"
+              "-m", "uvicorn", "gate:app", "--host", "127.0.0.1", "--port", "8787", "--no-proxy-headers"
             )
             Wait-CyClawEndpoint -Name "gateway" -Uri "http://127.0.0.1:8787/health" -Process $gateway
 

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -1621,6 +1621,40 @@ class TestProxyHeaderTrust:
         assert any("--no-proxy-headers" in ln for ln in cmd_lines), \
             "Dockerfile CMD must pass --no-proxy-headers to match gate._serve"
 
+    def test_ci_and_sandbox_uvicorn_spawns_disable_proxy_headers(self):
+        """Live uvicorn spawners that bypass gate._serve must pass the same
+        --no-proxy-headers flag the Dockerfile and macos/invoke-cyclaw.sh already
+        pin. Without it, uvicorn trusts X-Forwarded-For from any loopback peer.
+        """
+        from pathlib import Path
+        root = Path(__file__).resolve().parent.parent
+        shell_spawns = (
+            root / ".claude" / "skills" / "CyClaw-Sandbox" / "verify.sh",
+            root / ".claude" / "skills" / "CyClaw-Sandbox" / "smoke.sh",
+            root / ".codex" / "skills" / "Cyclaw-Sandbox" / "verify.sh",
+            root / ".codex" / "skills" / "Cyclaw-Sandbox" / "smoke.sh",
+        )
+        for path in shell_spawns:
+            spawn = [
+                line
+                for line in path.read_text(encoding="utf-8").splitlines()
+                if "uvicorn gate:app" in line and not line.lstrip().startswith("#")
+            ]
+            assert spawn, f"{path} no longer spawns uvicorn gate:app"
+            assert all("--no-proxy-headers" in line for line in spawn), (
+                f"{path} must pass --no-proxy-headers to match gate._serve"
+            )
+
+        ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+        assert "python -m uvicorn gate:app --host 127.0.0.1 --port 8787 --no-proxy-headers" in ci
+        assert '"--no-proxy-headers"' in ci
+
+        runner = (
+            root / ".codex" / "skills" / "cyclaw-sandbox-test" / "scripts" / "run_sandbox_test.py"
+        ).read_text(encoding="utf-8")
+        assert "--no-proxy-headers" in runner
+        assert '"-m", "uvicorn", "gate:app"' in runner
+
 
 class TestLoopbackBindGuard:
     """docs/THREAT_MODEL.md scopes CyClaw as single-operator and loopback-bound,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

PR #1393 pinned `proxy_headers=False` on `gate._serve`, the Dockerfile `CMD`, and `macos/invoke-cyclaw.sh`. CI live-smoke and the CyClaw-Sandbox / Codex verify+smoke launchers still spawned `uvicorn gate:app` without `--no-proxy-headers`. On a loopback bind, uvicorn's default trusts `X-Forwarded-For` from any local peer and rewrites the client IP that `_enforce_rate_limit` keys on.

This PR adds `--no-proxy-headers` to those remaining live spawners and pins them with a static test next to the existing Dockerfile check. It also initializes the in-process swarm Phase 3 `chunks` / `tokenized` lists before the BM25 try so a missing `rank_bm25` cannot `UnboundLocalError` the later Chroma loop (reproduced on a bare interpreter).

**Invariant / Governance Impact**
- None of I1–I6 change. No `gate.py` / `graph.py` / soul / sanitizer edits.
- Evidence: `python3.12 .claude/skills/invariant-guard/check_invariants.py` → 46 passed, 0 failed on this branch (same as `origin/main` @ `c09205b21ad8bf96e5b0da96e5acb9e5b3acfafb`).
- I6 isolation is untouched. Sandbox scripts remain out-of-band of the request path.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note:
Infrastructure / CI + CyClaw-Sandbox harness. Core graph/gate/soul path unchanged. Advisor review not required for topology; this only matches existing `gate._serve` proxy-header posture.

## Benefits / why

- Closes the leftover #1393 hole on every maintained uvicorn spawn that bypasses `gate.py` `main()`.
- CI macos/windows live smoke and operator `verify.sh` / `smoke.sh` now exercise the same proxy-header posture production uses.
- Swarm Phase 3 no longer emits a confusing secondary UnboundLocalError when BM25 deps are absent.

## Risks to monitor

- A spawn site that later drops `--no-proxy-headers` fails `TestProxyHeaderTrust.test_ci_and_sandbox_uvicorn_spawns_disable_proxy_headers`.
- Comment-only `uvicorn gate:app` examples in README / setup-guide are unchanged (operators who copy those still get the default). Not this PR's scope.
- No change to rate-limit math, TrustedHost, or same-origin checks.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Full pytest / `verify.sh` skipped this session: no torch/chromadb venv (expensive). Cheap baseline on `main` @ `c09205b2` and this branch: invariant-guard 46/46, doc-sync 0 drift, config-guard 0 fail / 1 known C9 warn, dep-guard 0 fail. In-process swarm 122/127 on a bare interpreter (httpx/rank_bm25/fastapi gaps, not this diff). Focused pytest after the commit: `TestProxyHeaderTrust.test_ci_and_sandbox_uvicorn_spawns_disable_proxy_headers` and `test_dockerfile_cmd_passes_no_proxy_headers` both passed.

## Further comments

- Graph topology, RAG-first entry, triple-gate, audit convergence, soul writes, and I6 imports are unchanged.
- This is not a gate.py logic change. It only makes harness/CI uvicorn argv match `_serve(proxy_headers=False)`.
- Sandbox / invariant-guard evidence is in the Checklist above.

## Merge order

- independent
- merge order: this is the only draft from this optimize run; merge when a human is satisfied

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24824a6f-bf14-41be-b37c-7b1c056c7659?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24824a6f-bf14-41be-b37c-7b1c056c7659&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

