### PR TITLE
[fix] - Require Python 3.12 on launcher venv fallback

### DIFF
--- a/macos/invoke-cyclaw.sh
+++ b/macos/invoke-cyclaw.sh
@@ -76,9 +76,20 @@ if [ ! -f "$REPO_DIR/gate.py" ]; then
   exit 1
 fi
 if [ ! -x "$VENV_PY" ]; then
-  VENV_PY="$(command -v python3 || true)"
-  if [ -z "$VENV_PY" ]; then
-    echo "No venv at $HOME_DIR/venv and no python3 on PATH. Re-run install-cyclaw.sh." >&2
+  # Same 3.12 probe as install-cyclaw.sh. Bare `python3` on macOS is often
+  # 3.11 (Xcode CLT / unversioned Homebrew), and CyClaw requires 3.12.
+  VENV_PY=""
+  for candidate in python3.12 python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+      ver="$("$candidate" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || true)"
+      if [ "$ver" = "3.12" ]; then
+        VENV_PY="$(command -v "$candidate")"
+        break
+      fi
+    fi
+  done
+  if [ -z "$VENV_PY" ] || [ ! -x "$VENV_PY" ]; then
+    echo "No venv at $HOME_DIR/venv and no Python 3.12.x on PATH. Re-run install-cyclaw.sh." >&2
     exit 1
   fi
 fi

--- a/powershell/Invoke-CyClaw.ps1
+++ b/powershell/Invoke-CyClaw.ps1
@@ -39,9 +39,25 @@ if (-not (Test-Path (Join-Path $Repo "gate.py"))) {
     throw "CyClaw repo not found at '$Repo'. Run Install-CyClaw.ps1 first (or pass -Repo)."
 }
 if (-not (Test-Path $VenvPy)) {
-    # Fall back to system python when the venv was skipped during install.
-    $VenvPy = (Get-Command python -ErrorAction SilentlyContinue).Source
-    if (-not $VenvPy) { throw "No venv at $Home_\venv and no python on PATH. Re-run Install-CyClaw.ps1." }
+    # Same 3.12 gate as Install-CyClaw.ps1. A generic `python` on PATH is
+    # often the Store stub or 3.11/3.13; CyClaw requires 3.12.
+    $fallback = $null
+    $py = Get-Command py -ErrorAction SilentlyContinue
+    if ($py) {
+        $exe = & py -3.12 -c "import sys; print(sys.executable)" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $exe) { $fallback = "$exe".Trim() }
+    }
+    if (-not $fallback) {
+        $python = Get-Command python -ErrorAction SilentlyContinue
+        if ($python) {
+            $v = & python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $v -eq "3.12") { $fallback = $python.Source }
+        }
+    }
+    if (-not $fallback) {
+        throw "No venv at $Home_\venv and no Python 3.12.x on PATH. Re-run Install-CyClaw.ps1."
+    }
+    $VenvPy = $fallback
 }
 
 $env:CYCLAW_HOME = $Home_

--- a/tests/test_macos_scripts.py
+++ b/tests/test_macos_scripts.py
@@ -54,6 +54,22 @@ def test_invoke_cyclaw_home_dir_matches_install_cyclaw() -> None:
     assert invoke_match.group(1) == install_match.group(1)
 
 
+def test_invoke_cyclaw_fallback_requires_python_312() -> None:
+    """A missing ~/.CyClaw/venv must not launch under a random python3.
+
+    install-cyclaw.sh already probes python3.12 then checks major.minor == 3.12.
+    The invoke fallback used to take `command -v python3` with no version gate.
+    """
+    text = (_REPO_ROOT / "macos" / "invoke-cyclaw.sh").read_text(encoding="utf-8")
+    fallback = text.split('if [ ! -x "$VENV_PY" ]; then', 1)[1]
+    fallback = fallback.split("export CYCLAW_HOME", 1)[0]
+    assert "python3.12" in fallback
+    assert 'print(f"{sys.version_info.major}.{sys.version_info.minor}")' in fallback
+    assert '[ "$ver" = "3.12" ]' in fallback
+    assert 'command -v python3 || true' not in fallback
+    assert "no Python 3.12.x on PATH" in fallback
+
+
 def test_invoke_cyclaw_disables_uvicorn_proxy_headers() -> None:
     """The Darwin launcher stays on uvicorn so --gate-port still works, but it
     must pass --no-proxy-headers like gate._serve / the Dockerfile CMD.

--- a/tests/test_powershell_windows_parity.py
+++ b/tests/test_powershell_windows_parity.py
@@ -132,6 +132,18 @@ def test_invoke_loads_persisted_api_key_from_dotenv() -> None:
     assert load_idx < text.index(warn)
 
 
+def test_invoke_fallback_requires_python_312() -> None:
+    """A missing %USERPROFILE%\\.CyClaw\\venv must not launch under any python."""
+    text = (_PS / "Invoke-CyClaw.ps1").read_text(encoding="utf-8")
+    fallback = text.split("if (-not (Test-Path $VenvPy)) {", 1)[1]
+    fallback = fallback.split("$env:CYCLAW_HOME = $Home_", 1)[0]
+    assert "py -3.12" in fallback
+    assert 'print(sys.executable)' in fallback
+    assert '$v -eq "3.12"' in fallback
+    assert "no Python 3.12.x on PATH" in fallback
+    assert "(Get-Command python -ErrorAction SilentlyContinue).Source" not in fallback
+
+
 def test_invoke_starts_gate_through_main_not_bare_uvicorn() -> None:
     """Only gate.main() -> _serve() applies the loopback bind guard, api.tls
     certfile/keyfile, and proxy_headers=False; a bare `uvicorn gate:app` would


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

`macos/invoke-cyclaw.sh` and `powershell/Invoke-CyClaw.ps1` fell back to any `python3` / `python` when `~/.CyClaw/venv` was missing. The installers already refuse anything but 3.12.x. On macOS the unversioned `python3` is often 3.11; on Windows `python` is often the Store stub or 3.11/3.13. CyClaw requires `>=3.12,<3.13`.

The invoke fallback now uses the same probe as the installers (`python3.12` then a major.minor check; Windows also tries `py -3.12` and resolves `sys.executable`). Static tests pin the new contract.

**Invariant / Governance Impact**
- None of I1–I6 change. No `gate.py` / `graph.py` / soul / sanitizer edits.
- Evidence: `python3.12 .claude/skills/invariant-guard/check_invariants.py` → 46 passed, 0 failed. Base `origin/main` @ `c09205b21ad8bf96e5b0da96e5acb9e5b3acfafb`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note:
Out-of-band macOS/Windows launchers. Core graph/gate/soul path unchanged.

## Benefits / why

- A missing venv no longer starts the gateway under the wrong interpreter (the CLAUDE.md 3.11/`shutil.rmtree(onexc=)` trap).
- Invoke and install now share the same 3.12 contract.

## Risks to monitor

- An operator who only has 3.11 on PATH and no venv now gets a clear refuse instead of a silent wrong-runtime start. That is intended.
- The venv path is unchanged. Existing installs that have `~/.CyClaw/venv` are unaffected.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Focused pytest: `test_invoke_cyclaw_fallback_requires_python_312` and `test_invoke_fallback_requires_python_312` plus the adjacent launcher contract tests. Full pytest / live `verify.sh` skipped (no torch venv). invariant-guard 46/46, doc-sync 0 drift.

## Further comments

- Not a gate.py logic change. Advisor not required for topology.
- Sandbox / invariant-guard evidence is in the Checklist above.

## Merge order

- independent
- merge order: after or before #1401; no shared files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24824a6f-bf14-41be-b37c-7b1c056c7659?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24824a6f-bf14-41be-b37c-7b1c056c7659&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

