### PR TITLE
[infra] - Run lint on every documented feature-branch prefix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,6 +41,10 @@ on:
       - 'grok/**'
       - 'codex/**'
       - 'kimi/**'
+      - 'agent/**'
+      - 'CyClaw/**'
+      - 'cyclaw/**'
+      - 'cursor/**'
   pull_request:
     branches: [main, cc]
 

--- a/.github/workflows/lora-finetune.yml
+++ b/.github/workflows/lora-finetune.yml
@@ -28,6 +28,7 @@ on:
       - 'agent/**'
       - 'CyClaw/**'
       - 'cyclaw/**'
+      - 'cursor/**'
     paths:
       - 'tools/lora_finetune/**'
       - '.github/workflows/lora-finetune.yml'

--- a/tests/test_lint_workflow_contract.py
+++ b/tests/test_lint_workflow_contract.py
@@ -11,3 +11,23 @@ def test_changed_python_paths_stay_nul_delimited_until_flake8_argv() -> None:
     assert "mapfile -d ''" in text
     assert 'flake8 -- "${FILES[@]}"' in text
     assert "CHANGED_FILES" not in text
+
+
+def test_lint_push_covers_documented_feature_prefixes() -> None:
+    """Push lint must fire for every vendor prefix the PR template allows,
+    plus cursor/** used by Cursor Cloud agents. lora-finetune.yml already
+    listed agent/CyClaw/cyclaw; lint.yml had only claude/grok/codex/kimi.
+    """
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    push = text.split("push:", 1)[1].split("pull_request:", 1)[0]
+    for prefix in (
+        "claude/**",
+        "grok/**",
+        "codex/**",
+        "kimi/**",
+        "agent/**",
+        "CyClaw/**",
+        "cyclaw/**",
+        "cursor/**",
+    ):
+        assert f"'{prefix}'" in push, f"lint.yml push filters missing {prefix}"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Proposed changes

`lint.yml` ran on push only for `main` plus `claude/**` / `grok/**` / `codex/**` / `kimi/**`. Pushes to `agent/**`, `CyClaw/**`, `cyclaw/**` (already in `lora-finetune.yml`) and `cursor/**` (Cursor Cloud agents) got no blocking F/B/S until a PR existed.

This adds those four prefixes to `lint.yml` and adds `cursor/**` to `lora-finetune.yml`. A contract test pins the lint push list.

`cc` as a `pull_request` base is left alone. That branch is gone on GitHub (last `cc` PRs were 2026-06). Adding the full `ci.yml` matrix there would be speculative.

**Invariant / Governance Impact**
- None of I1–I6 change. Workflow trigger lists only.
- Evidence: `python3.12 .claude/skills/invariant-guard/check_invariants.py` → 46 passed, 0 failed. Base `origin/main` @ `c09205b21ad8bf96e5b0da96e5acb9e5b3acfafb`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Invariant / Governance refinement (use this for changes that strengthen or evolve the 6 invariants, I6 isolation, or harness phases)

Optional free-text scope note:
Infrastructure / CI only.

## Benefits / why

- Feature-branch pushes get the same lint gate the documented vendor prefixes already have.
- Cursor Cloud branches stop waiting for a PR before F/B/S runs.

## Risks to monitor

- More lint runs on agent/CyClaw/cursor pushes. Lint is cheap relative to the test matrix.
- `pull_request` already covered `main` and `cc`; this change is push-only.

## Checklist

- [x] I have read the latest `docs/CyClaw Architecture Guide` (and any relevant Phase docs) and `SECURITY.md`
- [x] This change preserves all 6 security invariants and I6 module isolation (explicit evidence or invariant matrix included for core changes)
- [ ] Full sandbox validation has been run (`GROK_API_KEY=dummy pytest tests/ -q --tb=short`, and `bash .claude/skills/CyClaw-Sandbox/verify.sh` for core RAG/agentic paths) and passes with no regressions
- [x] No new external network dependencies or mandatory online LLM assumptions were introduced without explicit justification + offline fallback path
- [x] For any agentic/fsconnect change: two-phase audit, quota enforcement, governed delete/trash, and write guards have been verified
- [x] Relevant architecture docs or threat model notes have been updated if core behavior or topology changed
- [x] Commit messages follow the title prefix convention above
- [ ] For large or complex changes: before/after invariant matrix + sandbox evidence is included in "Further comments" or linked

Focused pytest: `tests/test_lint_workflow_contract.py` (2 passed). Full pytest / `verify.sh` skipped (no torch venv). invariant-guard 46/46, doc-sync 0 drift.

## Further comments

- Not a gate.py / graph.py change. Advisor not required.
- Independent of #1401 and #1402 (no shared files).

## Merge order

- independent
- merge order: after or before #1401 / #1402; no shared files

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-24824a6f-bf14-41be-b37c-7b1c056c7659?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-24824a6f-bf14-41be-b37c-7b1c056c7659&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

